### PR TITLE
Add author affiliations to Atom serialization

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ flask = "==1.0.2"
 arxiv = "==0.3.1"
 arxiv-base = "==0.12.1"
 rfeed = "==1.1.1"
-feedgen = "*"
+feedgen = "==0.7.0"
 
 [dev-packages]
 mypy = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "206b276dda7267f19bd6c88ae67209185a3677a234bb9f3f057eed9b996caefd"
+            "sha256": "993be7f7dff06935c921ac757436c46cdb16bb4aedb09e2a330ca9ef31781148"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -40,17 +40,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:1253809000b3b9020c6dde3e8b0b75e6c02547e2760656d8bccc40fd2a7284a6",
-                "sha256:e32a1a324ddfb652dedd550fd288ad85cc8d448ed19315f39fbe7b6171a30dc8"
+                "sha256:60bbb64ca5ff05ec3aecca582e33b516e774c739fa9e9591c1e3db512e81bc49",
+                "sha256:e59cf23e82156b8f4d8dcebd8fcae618b30ca10125f9e7222eb181a627913f0d"
             ],
-            "version": "==1.9.150"
+            "version": "==1.9.167"
         },
         "botocore": {
             "hashes": [
-                "sha256:946fd5e85378c3c597d6b9f495706576a0fc0000b216e30346ed7ee796ff50c8",
-                "sha256:f82e44af499a8f806c363ab4e26df82195b5b190c4169ccfbfbc98e55aa22bf7"
+                "sha256:bba0548c3638877aebe3356819b5235b9d39cd4d2ebac9946979a93e412bb777",
+                "sha256:d3424b05a13ac38efe225a2f75a72d3f949513980f737001ae9279edd81b1b31"
             ],
-            "version": "==1.12.150"
+            "version": "==1.12.167"
         },
         "certifi": {
             "hashes": [
@@ -157,34 +157,32 @@
         },
         "lxml": {
             "hashes": [
-                "sha256:03984196d00670b2ab14ae0ea83d5cc0cfa4f5a42558afa9ab5fa745995328f5",
-                "sha256:0815b0c9f897468de6a386dc15917a0becf48cc92425613aa8bbfc7f0f82951f",
-                "sha256:175f3825f075cf02d15099eb52658457cf0ff103dcf11512b5d2583e1d40f58b",
-                "sha256:30e14c62d88d1e01a26936ecd1c6e784d4afc9aa002bba4321c5897937112616",
-                "sha256:3210da6f36cf4b835ff1be853962b22cc354d506f493b67a4303c88bbb40d57b",
-                "sha256:40f60819fbd5bad6e191ba1329bfafa09ab7f3f174b3d034d413ef5266963294",
-                "sha256:43b26a865a61549919f8a42e094dfdb62847113cf776d84bd6b60e4e3fc20ea3",
-                "sha256:4a03dd682f8e35a10234904e0b9508d705ff98cf962c5851ed052e9340df3d90",
-                "sha256:62f382cddf3d2e52cf266e161aa522d54fd624b8cc567bc18f573d9d50d40e8e",
-                "sha256:7b98f0325be8450da70aa4a796c4f06852949fe031878b4aa1d6c417a412f314",
-                "sha256:846a0739e595871041385d86d12af4b6999f921359b38affb99cdd6b54219a8f",
-                "sha256:a3080470559938a09a5d0ec558c005282e99ac77bf8211fb7b9a5c66390acd8d",
-                "sha256:ad841b78a476623955da270ab8d207c3c694aa5eba71f4792f65926dc46c6ee8",
-                "sha256:afdd75d9735e44c639ffd6258ce04a2de3b208f148072c02478162d0944d9da3",
-                "sha256:b4fbf9b552faff54742bcd0791ab1da5863363fb19047e68f6592be1ac2dab33",
-                "sha256:b90c4e32d6ec089d3fa3518436bdf5ce4d902a0787dbd9bb09f37afe8b994317",
-                "sha256:b91cfe4438c741aeff662d413fd2808ac901cc6229c838236840d11de4586d63",
-                "sha256:bdb0593a42070b0a5f138b79b872289ee73c8e25b3f0bea6564e795b55b6bcdd",
-                "sha256:c4e4bca2bb68ce22320297dfa1a7bf070a5b20bcbaec4ee023f83d2f6e76496f",
-                "sha256:cec4ab14af9eae8501be3266ff50c3c2aecc017ba1e86c160209bb4f0423df6a",
-                "sha256:e83b4b2bf029f5104bc1227dbb7bf5ace6fd8fabaebffcd4f8106fafc69fc45f",
-                "sha256:e995b3734a46d41ae60b6097f7c51ba9958648c6d1e0935b7e0ee446ee4abe22",
-                "sha256:f679d93dec7f7210575c85379a31322df4c46496f184ef650d3aba1484b38a2d",
-                "sha256:fd213bb5166e46974f113c8228daaef1732abc47cb561ce9c4c8eaed4bd3b09b",
-                "sha256:fdcb57b906dbc1f80666e6290e794ab8fb959a2e17aa5aee1758a85d1da4533f",
-                "sha256:ff424b01d090ffe1947ec7432b07f536912e0300458f9a7f48ea217dd8362b86"
+                "sha256:06c7616601430aa140a69f97e3116308fffe0848f543b639a5ec2e8920ae72fd",
+                "sha256:177202792f9842374a8077735c69c41a4282183f7851443d2beb8ee310720819",
+                "sha256:19317ad721ceb9e39847d11131903931e2794e447d4751ebb0d9236f1b349ff2",
+                "sha256:36d206e62f3e5dbaafd4ec692b67157e271f5da7fd925fda8515da675eace50d",
+                "sha256:387115b066c797c85f9861a9613abf50046a15aac16759bc92d04f94acfad082",
+                "sha256:3ce1c49d4b4a7bc75fb12acb3a6247bb7a91fe420542e6d671ba9187d12a12c2",
+                "sha256:4d2a5a7d6b0dbb8c37dab66a8ce09a8761409c044017721c21718659fa3365a1",
+                "sha256:58d0a1b33364d1253a88d18df6c0b2676a1746d27c969dc9e32d143a3701dda5",
+                "sha256:62a651c618b846b88fdcae0533ec23f185bb322d6c1845733f3123e8980c1d1b",
+                "sha256:69ff21064e7debc9b1b1e2eee8c2d686d042d4257186d70b338206a80c5bc5ea",
+                "sha256:7060453eba9ba59d821625c6af6a266bd68277dce6577f754d1eb9116c094266",
+                "sha256:7d26b36a9c4bce53b9cfe42e67849ae3c5c23558bc08363e53ffd6d94f4ff4d2",
+                "sha256:83b427ad2bfa0b9705e02a83d8d607d2c2f01889eb138168e462a3a052c42368",
+                "sha256:923d03c84534078386cf50193057aae98fa94cace8ea7580b74754493fda73ad",
+                "sha256:b773715609649a1a180025213f67ffdeb5a4878c784293ada300ee95a1f3257b",
+                "sha256:baff149c174e9108d4a2fee192c496711be85534eab63adb122f93e70aa35431",
+                "sha256:bca9d118b1014b4c2d19319b10a3ebed508ff649396ce1855e1c96528d9b2fa9",
+                "sha256:ce580c28845581535dc6000fc7c35fdadf8bea7ccb57d6321b044508e9ba0685",
+                "sha256:d34923a569e70224d88e6682490e24c842907ba2c948c5fd26185413cbe0cd96",
+                "sha256:dd9f0e531a049d8b35ec5e6c68a37f1ba6ec3a591415e6804cbdf652793d15d7",
+                "sha256:ecb805cbfe9102f3fd3d2ef16dfe5ae9e2d7a7dfbba92f4ff1e16ac9784dbfb0",
+                "sha256:ede9aad2197a0202caff35d417b671f5f91a3631477441076082a17c94edd846",
+                "sha256:ef2d1fc370400e0aa755aab0b20cf4f1d0e934e7fd5244f3dd4869078e4942b9",
+                "sha256:f2fec194a49bfaef42a548ee657362af5c7a640da757f6f452a35da7dd9f923c"
             ],
-            "version": "==4.3.3"
+            "version": "==4.3.4"
         },
         "markupsafe": {
             "hashes": [
@@ -256,10 +254,10 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:7b9ad3213bff7d357f888e0fab5101b56fa1a0548ee77d121c3a3dbfbef4cb2e",
-                "sha256:f23d5cb7d862b104401d9021fc82e5fa0e0cf57b7660a1331425aab0c691d021"
+                "sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d",
+                "sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba"
             ],
-            "version": "==0.2.0"
+            "version": "==0.2.1"
         },
         "six": {
             "hashes": [
@@ -270,11 +268,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
-                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.24.3"
+            "version": "==1.25.3"
         },
         "uwsgi": {
             "hashes": [
@@ -369,6 +367,13 @@
             ],
             "index": "pypi",
             "version": "==0.7.1"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7",
+                "sha256:cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"
+            ],
+            "version": "==0.18"
         },
         "isort": {
             "hashes": [
@@ -494,12 +499,19 @@
             "index": "pypi",
             "version": "==0.9.1"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+            ],
+            "version": "==19.0"
+        },
         "pluggy": {
             "hashes": [
-                "sha256:25a1bc1d148c9a640211872b4ff859878d422bccb59c9965e04eed468a0aa180",
-                "sha256:964cedd2b27c492fbf0b7f58b3284a09cf7f99b0f715941fb24a439b3af1bd1a"
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
             ],
-            "version": "==0.11.0"
+            "version": "==0.12.0"
         },
         "py": {
             "hashes": [
@@ -541,13 +553,20 @@
             "index": "pypi",
             "version": "==2.3.1"
         },
+        "pyparsing": {
+            "hashes": [
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+            ],
+            "version": "==2.4.0"
+        },
         "pytest": {
             "hashes": [
-                "sha256:1a8aa4fa958f8f451ac5441f3ac130d9fc86ea38780dd2715e6d5c5882700b24",
-                "sha256:b8bf138592384bd4e87338cb0f256bf5f615398a649d4bd83915f0e4047a5ca6"
+                "sha256:4a784f1d4f2ef198fe9b7aef793e9fa1a3b2f84e822d9b3a64a181293a572d45",
+                "sha256:926855726d8ae8371803f7b2e6ec0a69953d9c6311fa7c3b6c1b929ff92d27da"
             ],
             "index": "pypi",
-            "version": "==4.5.0"
+            "version": "==4.6.3"
         },
         "pytest-easyread": {
             "hashes": [
@@ -614,6 +633,13 @@
                 "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
             ],
             "version": "==1.11.1"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
+                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
+            ],
+            "version": "==0.5.1"
         }
     }
 }

--- a/rss/domain.py
+++ b/rss/domain.py
@@ -9,6 +9,7 @@ class Author(NamedTuple):
     last_name: str
     full_name: str
     initials: str
+    affiliations: List[str]
 
 
 class Category(NamedTuple):

--- a/rss/index.py
+++ b/rss/index.py
@@ -198,7 +198,11 @@ def create_eprint(record: Hit) -> EPrint:
         last_name = hit_author['last_name']
         full_name = hit_author['full_name']
         initials = hit_author['initials']
-        author = Author(last_name, full_name, initials)
+        affiliations = []
+        if 'affiliation' in hit_author:
+            for affiliation in hit_author['affiliation']:
+                affiliations.append(affiliation)
+        author = Author(last_name, full_name, initials, affiliations)
         authors.append(author)
 
     # Copy the hit data for categories into the EPrint

--- a/rss/serializers/atom_1_0.py
+++ b/rss/serializers/atom_1_0.py
@@ -84,7 +84,7 @@ class Atom_1_0(Serializer):  # pylint: disable=too-few-public-methods
             for author in eprint.authors:
                 author_list = {"name": author.full_name}
                 entry.author(author_list)
-                if len(author.affiliations):
+                if len(author.affiliations) > 0:
                     entry.arxiv.affiliation(author.full_name, author.affiliations)
 
         results: str = fg.atom_str(pretty=True)

--- a/rss/serializers/atom_1_0.py
+++ b/rss/serializers/atom_1_0.py
@@ -34,11 +34,8 @@ class Atom_1_0(Serializer):  # pylint: disable=too-few-public-methods
         fg.link(href='http://arxiv.org/rss/version=atom_1.0', rel='self', type='application/atom+xml')
         fg.updated(datetime.utcnow().replace(tzinfo=utc))
 
-        # TODO - Try to remove generator element.  This doesn't work - code ignores "None"
-        # fg.generator(None)
         # TODO - We don't currently set "subtitle", but could do it like this
-        # fg.subtitle(
-        #     f"{archive['name']} ({archive.arxiv_id}) updates on the arXiv.org e-print archive")
+        # fg.subtitle(str.join(', ', eprints.categories) + " updates on the arXiv.org e-print archive")
 
         # Add each search result to the feed
         for eprint in eprints.eprints:
@@ -87,7 +84,8 @@ class Atom_1_0(Serializer):  # pylint: disable=too-few-public-methods
             for author in eprint.authors:
                 author_list = {"name": author.full_name}
                 entry.author(author_list)
-                # TODO - How can arxiv-specific affiliation elements be added to authors?
+                if len(author.affiliations):
+                    entry.arxiv.affiliation(author.full_name, author.affiliations)
 
         results: str = fg.atom_str(pretty=True)
         return results

--- a/rss/serializers/atom_extensions.py
+++ b/rss/serializers/atom_extensions.py
@@ -1,92 +1,94 @@
 """Classes derived from the Feedgen extension classes."""
 
-from typing import Dict
+from typing import Dict, List
 from feedgen.ext.base import BaseEntryExtension, BaseExtension
-from feedgen.entry import FeedEntry
-from feedgen.feed import FeedGenerator
 from lxml import etree
+from lxml.etree import Element
 
 
 class ArxivExtension(BaseExtension):
-    """Extension of the Feedgen base class to allow us to define namespaces."""
+    """Extension of the Feedgen base class to allow us to modify and extend its behavior."""
 
     def __init__(self: BaseExtension) -> None:
         """Noop initialization."""
         pass
 
-    @staticmethod
-    def extend_atom(atom_feed: FeedGenerator) -> FeedGenerator:
+    def extend_atom(self: BaseExtension, atom_feed: Element) -> Element:
         """
-        Assign the Atom feed generator to the extension.
+        Allow the extension to modify the initial feed element tree for Atom serialization.
 
         Parameters
         ----------
-        atom_feed
-            The FeedGenerator to use for Atom results.
+        atom_feed : Element
+            The feed's root element.
 
         Returns
         -------
-        FeedGenerator
-            The provided feed generator.
+        atom_feed : Element
+            The feed's root element.
 
         """
+        # Remove the unwanted "generator" element, which can't be erased though the API.
+        for child in atom_feed:
+            if child.tag == 'generator':
+                atom_feed.remove(child)
+
         return atom_feed
 
-    @staticmethod
-    def extend_rss(rss_feed: FeedGenerator) -> FeedGenerator:
+    def extend_rss(self: BaseExtension, rss_feed: Element) -> Element:
         """
-        Assign the RSS feed generator to the extension.
+        Allow the extension to modify the initial feed element tree for RSS serialization.
 
         Parameters
         ----------
-        rss_feed
-            The FeedGenerator to use for RSS results.
+        rss_feed : Element
+            The feed's root element.
 
         Returns
         -------
-        FeedGenerator
-            The provided feed generator.
+        rss_feed : Element
+            The feed's root element.
 
         """
         return rss_feed
 
-    @staticmethod
-    def extend_ns() -> Dict[str, str]:
+    def extend_ns(self: BaseExtension) -> Dict[str, str]:
         """
-        Assign the feed's namespace string.
+        Define the feed's namespaces.
 
         Returns
         -------
-        str
-            The definition string for the "arxiv" namespace.
+        namespaces : Dict[str, str]
+            Definitions of the "arxiv" namespaces.
 
         """
         return {'arxiv': 'http://arxiv.org/schemas/atom'}
 
 
 class ArxivEntryExtension(BaseEntryExtension):
-    """Extension of the Feedgen base class to allow us to add elements to the Atom output."""
+    """Extension of the Feedgen Entry base class to allow us to modify and extend its behavior."""
 
     def __init__(self: BaseEntryExtension):
         """Initialize the member values to all be empty."""
-        self.__arxiv_comment = None
-        self.__arxiv_primary_category = None
-        self.__arxiv_doi = None
-        self.__arxiv_affiliation = None
-        self.__arxiv_journal_ref = None
+        self.__arxiv_comment: str = None
+        self.__arxiv_primary_category: str = None
+        self.__arxiv_doi: Dict = None
+        self.__arxiv_affiliation: str = None
+        self.__arxiv_journal_ref: str = None
+        self.__arxiv_affiliations: Dict = {}
 
-    def extend_atom(self: BaseEntryExtension, entry: FeedEntry) -> FeedEntry:
+    def extend_atom(self, entry: Element) -> Element:
         """
-        Add this extension's new elements to the Atom feed entry.
+        Allow the extension to modify the entry element for Atom serialization.
 
         Parameters
         ----------
-        entry
+        entry : Element
             The FeedEntry to modify.
 
         Returns
         -------
-        FeedEntry
+        entry : Element
             The modified entry.
 
         """
@@ -108,70 +110,96 @@ class ArxivEntryExtension(BaseEntryExtension):
                 doi_element = etree.SubElement(entry, '{http://arxiv.org/schemas/atom}doi')
                 doi_element.text = doi
 
+        # Check each of the entry's author nodes
+        for entry_child in entry:
+            if entry_child.tag == 'author':
+                author = entry_child
+                for author_child in author:
+                    # If the author's name is in the affiliation dictionary, add Elements for all of its affiliations.
+                    if author_child.tag == 'name':
+                        name = author_child.text
+                        affiliations = self.__arxiv_affiliations[name]
+                        for affiliation in affiliations:
+                            element = etree.SubElement(author, '{http://arxiv.org/schemas/atom}affiliation')
+                            element.text = affiliation
+
         return entry
 
-    @staticmethod
-    def extend_rss(entry: FeedEntry) -> FeedEntry:
+    def extend_rss(self, entry: Element) -> Element:
         """
-        Add this extension's new elements to the RSS feed entry.
+        Allow the extension to modify the entry element for RSS serialization.
 
         Parameters
         ----------
-        entry
+        entry : Element
             The FeedEntry to modify.
 
         Returns
         -------
-        FeedEntry
-            The modfied entry.
+        entry : Element
+            The modified entry.
 
         """
         return entry
 
-    def comment(self: BaseEntryExtension, text: str) -> None:
+    def comment(self, text: str) -> None:
         """
         Assign the comment value to this entry.
 
         Parameters
         ----------
-        text
+        text : str
             The new comment text.
 
         """
         self.__arxiv_comment = text
 
-    def primary_category(self: BaseEntryExtension, text: str) -> None:
+    def primary_category(self, text: str) -> None:
         """
         Assign the primary_category value to this entry.
 
         Parameters
         ----------
-        text
+        text : str
             The new primary_category name.
 
         """
         self.__arxiv_primary_category = text
 
-    def journal_ref(self: BaseEntryExtension, text: str) -> None:
+    def journal_ref(self, text: str) -> None:
         """
         Assign the journal_ref value to this entry.
 
         Parameters
         ----------
-        text
+        text : str
             The new journal_ref value.
 
         """
         self.__arxiv_journal_ref = text
 
-    def doi(self: BaseEntryExtension, list: Dict[str, str]) -> None:
+    def doi(self, doi_list: Dict[str, str]) -> None:
         """
-        Assign the doi value to this entry.
+        Assign the set of DOI definitions for this entry.
 
         Parameters
         ----------
-        list
-            The new list of DOI assignments.
+        doi_list : Dict[str, str]
+            A dictionary of DOI assignments.
 
         """
-        self.__arxiv_doi = list
+        self.__arxiv_doi = doi_list
+
+    def affiliation(self, full_name: str, affiliations: List[str]) -> None:
+        """
+        Assign an affiliation for one author of this entry.
+
+        Parameters
+        ----------
+        full_name : str
+            An author's full name.
+        affiliations : List[str]
+            The code for the author's affiliated institution.
+
+        """
+        self.__arxiv_affiliations[full_name] = affiliations

--- a/rss/serializers/serializer.py
+++ b/rss/serializers/serializer.py
@@ -23,8 +23,8 @@ class Serializer(ABC):  # pylint: disable=too-few-public-methods
 
         Returns
         -------
-        data : str
-            The serialized results of the search.
+        data : Tuple[str, int]
+            The serialized results of the search plus the operation's HTTP status code.
 
         """
         pass


### PR DESCRIPTION
The Atom serialization did not provide a way to include author affiliations, which are defined in the arXiv schema.  The FeedGenerator extension for Atom has been augmented to allow this information to be collected and serialized for each author.

A list of affiliations was added to the domain model for an author and is populated by the indexer.  The serializer passes this information on to the extension, which prints the affiliation elements during serialization.

The automatically included "generator" element is also removed from the output, and several method signatures and docstrings were corrected.